### PR TITLE
aggregated OCR in batch

### DIFF
--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -51,6 +51,16 @@ function islandora_newspaper_batch_form($form, &$form_state, $object) {
         '#description' => t('Whether or not we should generate OCR for the pages of the newspaper issue.'),
         '#default_value' => TRUE,
       );
+      $form['aggregate_ocr'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Aggregate OCR?'),
+        '#description' => t('Whether or not we should generate OCR for the issues after ingesting all of the pages.'),
+        '#default_value' => FALSE,
+        '#states' => array(
+          'invisible' => array(
+            ':input[name="generate_ocr"]' => array('checked' => FALSE),
+          ),
+        ),
     }
   }
   $form['email_admin'] = array(

--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -61,6 +61,7 @@ function islandora_newspaper_batch_form($form, &$form_state, $object) {
             ':input[name="generate_ocr"]' => array('checked' => FALSE),
           ),
         ),
+      );
     }
   }
   $form['email_admin'] = array(

--- a/includes/islandora_newspaper_batch.inc
+++ b/includes/islandora_newspaper_batch.inc
@@ -425,6 +425,9 @@ class IslandoraNewspaperIssueBatchObject extends IslandoraNewspaperFlatBatchObje
     if (isset($this->preprocessorParameters['create_pdfs']) && $this->preprocessorParameters['create_pdfs']) {
       islandora_paged_content_set_pdf_flag($this);
     }
+    if (isset($this->preprocessorParameters['aggregate_ocr']) && $this->preprocessorParameters['aggregate_ocr']) {
+      islandora_paged_content_set_ocr_flag($this);
+    }
     // Identify the source of this object.
     $this->relationships->add(ISLANDORA_RELS_EXT_URI, 'newspaper-batched', 'true', RELS_TYPE_PLAIN_LITERAL);
     if (isset($this->preprocessorParameters['email_admin']) && $this->preprocessorParameters['email_admin']) {

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -54,6 +54,10 @@ function islandora_newspaper_batch_drush_command() {
         'description' => 'A flag to allow for conditional OCR generation.',
         'value' => 'optional',
       ),
+      'aggregate_ocr' => array(
+        'description' => 'A flag to cause OCR to be aggregated to issues, if OCR is also being generated per-page.',
+        'value' => 'optional',
+      ),
       'email_admin' => array(
         'description' => 'A flag to notify the site admin when the newspaper issue is fully ingested (depends on Rules being enabled).',
         'value' => 'optional',
@@ -90,6 +94,7 @@ function drush_islandora_newspaper_batch_preprocess() {
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOf'),
     'create_pdfs' => drush_get_option('create_pdfs', FALSE),
+    'aggregate_ocr' => drush_get_option('aggregate_ocr', FALSE),
     'email_admin' => drush_get_option('email_admin', FALSE),
     'wait_for_metadata' => drush_get_option('wait_for_metadata', FALSE),
     'directory_dedup' => drush_get_option('directory_dedup', FALSE),


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1533
# What does this Pull Request do?

Adds the option to aggregate OCR to the parent for both interface and drush batch ingests.
# How should this be tested?
- A Drush batch ingest should be attempted both with and without the new 'aggregate_ocr' flag set.
- An issue should be ingested through the newspaper batch UI with and without the aggregate OCR flag checked.
- Default behaviour should be checked to see if it matches previous default behaviour.
# Background context:

The purpose of ISLANDORA-1533 is to allow OCR datastreams to be aggregated and stored with the parent paged object so they can be indexed into Solr, and so that pages can be hidden from search results. This pull request adds the ability to aggregate that OCR at the time of batch ingest.
# Screenshots (if appropriate)
## Before Screenshot

![newspaper batch before](https://cloud.githubusercontent.com/assets/3406327/10948008/b6a3df8c-8301-11e5-9602-fb8b1fe18b18.png)
## After Screenshot

![newspaper batch after](https://cloud.githubusercontent.com/assets/3406327/10948011/bb12880c-8301-11e5-9c8d-7401f2d9068e.png)
# Additional Information

This change depends on https://github.com/Islandora/islandora_paged_content/pull/108

**Tagging:** @Islandora/7-x-1-x-committers as well as @mjordan who is the component manager here.

---

With apologies for the copy-paste from https://github.com/Islandora/islandora_book_batch/pull/48,
QA Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
