### PR TITLE
Address ISLANDORA-1579.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,19 @@ The ingest is a two-step process:
   be completed outside of a batch process.
 * Ingest: The data is actually processed and ingested. This happens inside of
   a Drupal batch.
-  
+
 **Usage**
 
 The base ZIP/directory preprocessor can be called as a drush script (see `drush help islandora_newspaper_batch_preprocess` for additional parameters):
 
+Drush made the `target` parameter reserved as of Drush 7. To allow for backwards compatability this will be preserved.
+
+Drush 7 and above:
+
 `drush -v --user=admin --uri=http://localhost islandora_newspaper_batch_preprocess --type=directory --scan_target=/path/to/issues --namespace=dailyplanet --parent=islandora:dailyplanet`
+
+Drush 6 and below:
+`drush -v --user=admin --uri=http://localhost islandora_newspaper_batch_preprocess --type=directory --target=/path/to/issues --namespace=dailyplanet --parent=islandora:dailyplanet`
 
 This will populate the queue (stored in the Drupal database) with base entries. Note that the --parent parmater must be a newspaper, not a collection.
 
@@ -59,7 +66,7 @@ The queue of preprocessed items can then be processed:
 
 `drush -v --user=admin --uri=http://localhost islandora_batch_ingest`
 
-**Sample Issue-level MODS.xml file** 
+**Sample Issue-level MODS.xml file**
 
 Here is a sample MODS file describing a newspaper issue. Note that it does not contain a `<relatedItem>` element as a direct child of `<mods>`:
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Drush 7 and above:
 Drush 6 and below:
 `drush -v --user=admin --uri=http://localhost islandora_newspaper_batch_preprocess --type=directory --target=/path/to/issues --namespace=dailyplanet --parent=islandora:dailyplanet`
 
-This will populate the queue (stored in the Drupal database) with base entries. Note that the --parent parmater must be a newspaper, not a collection.
+This will populate the queue (stored in the Drupal database) with base entries. Note that the --parent parameter must be a newspaper, not a collection.
 
-Batches must be broken up into separate directories (or Zip files), such that each directory at the "top" level (in the scan_target directory or Zip file) represents a newspaper issue. Newspaper pages are their own directories inside of each newsppaper issue directory.
+Batches must be broken up into separate directories (or Zip files), such that each directory at the "top" level (in the target directory or Zip file) represents a newspaper issue. Newspaper pages are their own directories inside of each newsppaper issue directory.
 
 Files are assigned to object datastreams based on their basename, so a folder structure like:
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The ingest is a two-step process:
 
 The base ZIP/directory preprocessor can be called as a drush script (see `drush help islandora_newspaper_batch_preprocess` for additional parameters):
 
-`drush -v --user=admin --uri=http://localhost islandora_newspaper_batch_preprocess --type=directory --target=/path/to/issues --namespace=dailyplanet --parent=islandora:dailyplanet`
+`drush -v --user=admin --uri=http://localhost islandora_newspaper_batch_preprocess --type=directory --scan_target=/path/to/issues --namespace=dailyplanet --parent=islandora:dailyplanet`
 
 This will populate the queue (stored in the Drupal database) with base entries. Note that the --parent parmater must be a newspaper, not a collection.
 
-Batches must be broken up into separate directories (or Zip files), such that each directory at the "top" level (in the target directory or Zip file) represents a newspaper issue. Newspaper pages are their own directories inside of each newsppaper issue directory.
+Batches must be broken up into separate directories (or Zip files), such that each directory at the "top" level (in the scan_target directory or Zip file) represents a newspaper issue. Newspaper pages are their own directories inside of each newsppaper issue directory.
 
 Files are assigned to object datastreams based on their basename, so a folder structure like:
 

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -22,7 +22,7 @@ function islandora_newspaper_batch_drush_command() {
         'description' => 'Either "directory" or "zip".',
         'required' => TRUE,
       ),
-      'target' => array(
+      'scan_target' => array(
         'description' => 'The target to directory or zip file to scan.',
         'required' => TRUE,
       ),
@@ -89,7 +89,7 @@ function drush_islandora_newspaper_batch_preprocess() {
   $parameters = array(
     'type' => drush_get_option('type'),
     'namespace' => drush_get_option('namespace'),
-    'target' => drush_get_option('target'),
+    'scan_target' => drush_get_option('scan_target'),
     'parent' => drush_get_option('parent', 'islandora:newspaperCollection'),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOf'),

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -72,7 +72,7 @@ function islandora_newspaper_batch_drush_command() {
   // backwards compatibility both will be supported. Not using
   // strict-option-handling (http://www.drush.org/en/master/strict-options) as
   // it requires manual argument parsing.
-  if (drush_core_version() >= 7) {
+  if (DRUSH_VERSION >= 7) {
     $items['islandora_newspaper_batch_preprocess']['options']['scan_target'] = array(
       'description' => 'The target to directory or zip file to scan.',
       'required' => TRUE,
@@ -100,7 +100,7 @@ function drush_islandora_newspaper_batch_preprocess() {
   $parameters = array(
     'type' => drush_get_option('type'),
     'namespace' => drush_get_option('namespace'),
-    'target' => drush_core_version() >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
+    'target' => DRUSH_VERSION >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
     'parent' => drush_get_option('parent', 'islandora:newspaperCollection'),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOf'),

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -22,10 +22,6 @@ function islandora_newspaper_batch_drush_command() {
         'description' => 'Either "directory" or "zip".',
         'required' => TRUE,
       ),
-      'scan_target' => array(
-        'description' => 'The target to directory or zip file to scan.',
-        'required' => TRUE,
-      ),
       'namespace' => array(
         'description' => 'The namespace for objects created by this command.  Defaults to namespace set in Fedora config.',
         'required' => FALSE,
@@ -72,7 +68,22 @@ function islandora_newspaper_batch_drush_command() {
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
-
+  // XXX: The target parameter became reserved in Drush 7 and above, for
+  // backwards compatibility both will be supported. Not using
+  // strict-option-handling (http://www.drush.org/en/master/strict-options) as
+  // it requires manual argument parsing.
+  if (drush_core_version() >= 7) {
+    $items['islandora_newspaper_batch_preprocess']['options']['scan_target'] = array(
+      'description' => 'The target to directory or zip file to scan.',
+      'required' => TRUE,
+    );
+  }
+  else {
+    $items['islandora_newspaper_batch_preprocess']['options']['target'] = array(
+      'description' => 'The target to directory or zip file to scan.',
+      'required' => TRUE,
+    );
+  }
   return $items;
 }
 
@@ -89,7 +100,7 @@ function drush_islandora_newspaper_batch_preprocess() {
   $parameters = array(
     'type' => drush_get_option('type'),
     'namespace' => drush_get_option('namespace'),
-    'scan_target' => drush_get_option('scan_target'),
+    'target' => drush_core_version() >= 7 ? drush_get_option('scan_target') : drush_get_option('target'),
     'parent' => drush_get_option('parent', 'islandora:newspaperCollection'),
     'parent_relationship_uri' => drush_get_option('parent_relationship_uri', 'info:fedora/fedora-system:def/relations-external#'),
     'parent_relationship_pred' => drush_get_option('parent_relationship_pred', 'isMemberOf'),


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1579
# What does this Pull Request do?

Changes the `target` option to `scan_target`. The `target` option appears to clash (At least in drush 7.x) with drush's `target`. Changing it to a non-conflicting option namespace resolves the issue. Additionally, it provides backward compatibility for drush 6.x.
# How should this be tested?

Do a batch ingest with drush 6.x using the existing option, and do a batch ingest using drush 7.x with the new option.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.

**Tagging:** @mjordan  

Release branch pull request: #12 
