### PR TITLE
add ocr/hocr ignore options

### DIFF
--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -56,7 +56,7 @@ function islandora_newspaper_batch_form($form, &$form_state, $object) {
         '#title' => t('Generate HOCR'),
         '#description' => t('Generate HOCR for the pages of each newspaper issue.'),
         '#default_value' => TRUE,
-      ),
+      );
       $form['aggregate_ocr'] = array(
         '#type' => 'checkbox',
         '#title' => t('Aggregate OCR'),

--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -47,14 +47,20 @@ function islandora_newspaper_batch_form($form, &$form_state, $object) {
     if ($derive['ocr']) {
       $form['generate_ocr'] = array(
         '#type' => 'checkbox',
-        '#title' => t('Generate OCR?'),
-        '#description' => t('Whether or not we should generate OCR for the pages of the newspaper issue.'),
+        '#title' => t('Generate OCR'),
+        '#description' => t('Generate HOCR for the pages of each newspaper issue.'),
         '#default_value' => TRUE,
       );
+      $form['generate_hocr'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Generate HOCR'),
+        '#description' => t('Generate HOCR for the pages of each newspaper issue.'),
+        '#default_value' => TRUE,
+      ),
       $form['aggregate_ocr'] = array(
         '#type' => 'checkbox',
-        '#title' => t('Aggregate OCR?'),
-        '#description' => t('Whether or not we should generate OCR for the issues after ingesting all of the pages.'),
+        '#title' => t('Aggregate OCR'),
+        '#description' => t('Consolidate the page OCR and add it to the issues after ingesting all of the pages.'),
         '#default_value' => FALSE,
         '#states' => array(
           'invisible' => array(

--- a/includes/batch.form.inc
+++ b/includes/batch.form.inc
@@ -48,7 +48,7 @@ function islandora_newspaper_batch_form($form, &$form_state, $object) {
       $form['generate_ocr'] = array(
         '#type' => 'checkbox',
         '#title' => t('Generate OCR'),
-        '#description' => t('Generate HOCR for the pages of each newspaper issue.'),
+        '#description' => t('Generate OCR for the pages of each newspaper issue.'),
         '#default_value' => TRUE,
       );
       $form['generate_hocr'] = array(

--- a/includes/islandora_newspaper_batch.inc
+++ b/includes/islandora_newspaper_batch.inc
@@ -490,9 +490,10 @@ class IslandoraNewspaperPageBatchObject extends IslandoraNewspaperFlatBatchObjec
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
     // Add content model relationship.
     $this->models = 'islandora:newspaperPageCModel';
+    // If one is set, both are.
     if (isset($this->preprocessorParameters['generate_ocr'])) {
       module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
-      islandora_ocr_set_generate_ocr_rels_ext_statement($this, $this->preprocessorParameters['generate_ocr']);
+      islandora_ocr_set_generating_rels_ext_statements($this, (bool) $this->preprocessorParameters['generate_ocr'], (bool) $this->preprocessorParameters['generate_hocr']);
     }
   }
 }

--- a/includes/islandora_newspaper_batch.inc
+++ b/includes/islandora_newspaper_batch.inc
@@ -490,7 +490,9 @@ class IslandoraNewspaperPageBatchObject extends IslandoraNewspaperFlatBatchObjec
     islandora_paged_content_set_relationship($rels_ext, FEDORA_RELS_EXT_URI, 'isMemberOf', $this->parentId);
     // Add content model relationship.
     $this->models = 'islandora:newspaperPageCModel';
-    // If one is set, both are.
+    // The existence of the generate_ocr and generate_hocr parameters is
+    // dependent on the existence of the islandora_ocr module, so one
+    // isset() will suffice.
     if (isset($this->preprocessorParameters['generate_ocr'])) {
       module_load_include('inc', 'islandora_ocr', 'includes/derivatives');
       islandora_ocr_set_generating_rels_ext_statements($this, (bool) $this->preprocessorParameters['generate_ocr'], (bool) $this->preprocessorParameters['generate_hocr']);

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -122,8 +122,10 @@ function drush_islandora_newspaper_batch_preprocess() {
     $parameters['content_models'] = array('islandora:newspaperIssueCModel');
   }
 
-  $parameters['generate_ocr'] = !((bool) drush_get_option('do_not_generate_ocr', FALSE));
-  $parameters['generate_hocr'] = !((bool) drush_get_option('do_not_generate_hocr', FALSE));
+  if (module_exists('islandora_ocr')) {
+    $parameters['generate_ocr'] = !((bool) drush_get_option('do_not_generate_ocr', FALSE));
+    $parameters['generate_hocr'] = !((bool) drush_get_option('do_not_generate_hocr', FALSE));
+  }
 
   $preprocessor = new IslandoraNewspaperBatch($connection, $parameters);
 

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -50,6 +50,10 @@ function islandora_newspaper_batch_drush_command() {
         'description' => 'A flag to allow for conditional OCR generation.',
         'value' => 'optional',
       ),
+      'do_not_generate_hocr' => array(
+        'description' => 'A flag to allow for conditional HOCR generation.',
+        'value' => 'optional',
+      ),
       'aggregate_ocr' => array(
         'description' => 'A flag to cause OCR to be aggregated to issues, if OCR is also being generated per-page.',
         'value' => 'optional',
@@ -118,12 +122,9 @@ function drush_islandora_newspaper_batch_preprocess() {
     $parameters['content_models'] = array('islandora:newspaperIssueCModel');
   }
 
-  if ($do_not_generate = drush_get_option('do_not_generate_ocr', FALSE)) {
-    $parameters['generate_ocr'] = FALSE;
-  }
-  else {
-    $parameters['generate_ocr'] = TRUE;
-  }
+  $parameters['generate_ocr'] = !((bool) drush_get_option('do_not_generate_ocr', FALSE));
+  $parameters['generate_hocr'] = !((bool) drush_get_option('do_not_generate_hocr', FALSE));
+
   $preprocessor = new IslandoraNewspaperBatch($connection, $parameters);
 
   // Pass the preprocessor off to run.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2012

* Other Relevant Links: Hard-requirement on https://github.com/Islandora/islandora_ocr/pull/81

# What does this Pull Request do?
Adds the option to ignore OCR/HOCR derivative generation when batch ingesting newspaper issues through the UI/Drush.
Also some language updates to clarify some odd things.

# What's new?
* Options in the newspaper issue batch ingest UI to opt out of OCR/HOCR derivative generation individually, not just one for both.
* A new flag, --do_not_generate_hocr, to opt out of HOCR derivative generation on Drush batches.
* The --do_not_generate_ocr flag now only opts out of OCR derivative generation.

# How should this be tested?
* Run the UI newspaper issue batch ingest and test each of the OCR/HOCR opt-out options.
* Run the drush newspaper issue batch ingest with the --do_not_generate_ocr and/or the --do_not_generate_hocr flags.
In all cases, OCR/HOCR should only be generated if it isn't opted out of.

# Additional Notes:
This has the potential to impact shell scripts that perform Drush scripting given the splitting of --do_not_generate_ocr into --do_not_generate_ocr and --do_not_generate_hocr. Shell scripts that currently rely on this flag would need to be updated to have flags split out.

# Interested parties
@jordandukart bein' the person on the thing
