### PR TITLE
Replaced 'collection' with 'newspaper object' in README and drush scr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Options:
  --do_not_generate_ocr                     A flag to allow for conditional OCR generation.                                                              
  --email_admin                             A flag to notify the site admin when the newspaper issue is fully ingested (depends on Rules being enabled). 
  --namespace                               The namespace for objects created by this command.  Defaults to namespace set in Fedora config.              
- --parent                                  The collection to which the generated items should be added.  Only applies to the "newspaper issue" level    
+ --parent                                  The newspaper object to which the generated items should be added.  Only applies to the "newspaper issue" level    
                                            object. If "directory" and the directory containing the newspaper issue description is a valid PID, it will  
                                            be set as the parent. If this is specified and itself is a PID, all newspapers issue will be related to the  
                                            given PID. Required.                                                                                         

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -31,7 +31,7 @@ function islandora_newspaper_batch_drush_command() {
         'value' => 'optional',
       ),
       'parent' => array(
-        'description' => 'The collection to which the generated items should be added.  Only applies to the "newspaper issue" level object. If "directory" and the directory containing the newspaper issue description is a valid PID, it will be set as the parent. If this is specified and itself is a PID, all newspapers issue will be related to the given PID.',
+        'description' => 'The newspaper object to which the generated items should be added.  Only applies to the "newspaper issue" level object. If "directory" and the directory containing the newspaper issue description is a valid PID, it will be set as the parent. If this is specified and itself is a PID, all newspapers issue will be related to the given PID.',
         'required' => TRUE,
       ),
       'parent_relationship_uri' => array(


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?

Replaces the misleading reference to 'collection' with the more accurate 'newspaper object' in the drush help and in README.md. In fact, if you use a collection object as the value for the `--parent` parameter, drush very helpfully tells you "The specified parent (islandora:newspaper_collection) is not a newspaper object." (replacing 'islandora:newspaper_collection' with whatever PID you supplied).

# How should this be tested?

n/a

# Interested parties
@Islandora/7-x-1-x-committers
