### PR TITLE
Add output_set_id option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,24 @@ drush help islandora_newspaper_batch_preprocess
 Preprocessed newspaper issues into database entries.
 
 Options:
- --aggregate_ocr                           A flag to cause OCR to be aggregated to issues, if OCR is also being generated per-page.                     
- --content_models                          A comma-separated list of content models to assign to the objects. Only applies to the "newspaper issue"     
-                                           level object.                                                                                                
- --create_pdfs                             A flag to cause PDFs to be created in newspaper issues. Page PDF creation is dependant on the configuration  
-                                           within Drupal proper.                                                                                        
- --directory_dedup                         A flag to indicate that we should avoid repreprocessing newspaper issues which are located in directories.   
- --do_not_generate_ocr                     A flag to disallow conditional OCR generation.                                                 
-
- --do_not_generate_hocr                    A flag to disallow conditional HOCR generation.                                               
-
- --email_admin                             A flag to notify the site admin when the newspaper issue is fully ingested (depends on Rules being enabled). 
- --namespace                               The namespace for objects created by this command.  Defaults to namespace set in Fedora config.              
- --parent                                  The newspaper object to which the generated items should be added.  Only applies to the "newspaper issue" level    
-                                           object. If "directory" and the directory containing the newspaper issue description is a valid PID, it will  
-                                           be set as the parent. If this is specified and itself is a PID, all newspapers issue will be related to the  
-                                           given PID. Required.                                                                                         
- --parent_relationship_pred                The predicate of the relationship to the parent. Defaults to "isMemberOf".                                   
- --parent_relationship_uri                 The namespace URI of the relationship to the parent. Defaults to                                             
-                                           "info:fedora/fedora-system:def/relations-external#".                                                         
- --target                                  The target to directory or zip file to scan. Required.                                                       
- --type                                    Either "directory" or "zip". Required.                                                                       
- --wait_for_metadata                       A flag to indicate that we should hold off on trying to ingest newspaper issues until we have metadata       
-                                           available for them at the newspaper issue level.
+ --aggregate_ocr                           A flag to cause OCR to be aggregated to issues, if OCR is also being generated per-page.                                          
+ --content_models                          A comma-separated list of content models to assign to the objects. Only applies to the "newspaper issue" level object.            
+ --create_pdfs                             A flag to cause PDFs to be created in newspaper issues. Page PDF creation is dependant on the configuration within Drupal proper. 
+ --directory_dedup                         A flag to indicate that we should avoid repreprocessing newspaper issues which are located in directories.                        
+ --do_not_generate_hocr                    A flag to disallow conditional HOCR generation.                                                                                   
+ --do_not_generate_ocr                     A flag to disallow conditional OCR generation.                                                                                    
+ --email_admin                             A flag to notify the site admin when the newspaper issue is fully ingested (depends on Rules being enabled).                      
+ --namespace                               The namespace for objects created by this command.  Defaults to namespace set in Fedora config.                                   
+ --output_set_id                           A flag to indicate whether to print the set ID of the preprocessed newspaper issues.                                                     
+ --parent                                  The newspaper object to which the generated items should be added.  Only applies to the "newspaper issue" level object. If        
+                                           "directory" and the directory containing the newspaper issue description is a valid PID, it will be set as the parent. If this is 
+                                           specified and itself is a PID, all newspapers issue will be related to the given PID. Required.                                   
+ --parent_relationship_pred                The predicate of the relationship to the parent. Defaults to "isMemberOf".                                                        
+ --parent_relationship_uri                 The namespace URI of the relationship to the parent. Defaults to "info:fedora/fedora-system:def/relations-external#".             
+ --scan_target                             The target to directory or zip file to scan. Required.                                                                            
+ --type                                    Either "directory" or "zip". Required.                                                                                            
+ --wait_for_metadata                       A flag to indicate that we should hold off on trying to ingest newspaper issues until we have metadata available for them at the  
+                                           newspaper issue level.
 
 Aliases: inbp
 ```

--- a/README.md
+++ b/README.md
@@ -27,22 +27,22 @@ drush help islandora_newspaper_batch_preprocess
 Preprocessed newspaper issues into database entries.
 
 Options:
- --aggregate_ocr                           A flag to cause OCR to be aggregated to issues, if OCR is also being generated per-page.                                          
- --content_models                          A comma-separated list of content models to assign to the objects. Only applies to the "newspaper issue" level object.            
+ --aggregate_ocr                           A flag to cause OCR to be aggregated to issues, if OCR is also being generated per-page.
+ --content_models                          A comma-separated list of content models to assign to the objects. Only applies to the "newspaper issue" level object. 
  --create_pdfs                             A flag to cause PDFs to be created in newspaper issues. Page PDF creation is dependant on the configuration within Drupal proper. 
- --directory_dedup                         A flag to indicate that we should avoid repreprocessing newspaper issues which are located in directories.                        
- --do_not_generate_hocr                    A flag to disallow conditional HOCR generation.                                                                                   
- --do_not_generate_ocr                     A flag to disallow conditional OCR generation.                                                                                    
- --email_admin                             A flag to notify the site admin when the newspaper issue is fully ingested (depends on Rules being enabled).                      
- --namespace                               The namespace for objects created by this command.  Defaults to namespace set in Fedora config.                                   
- --output_set_id                           A flag to indicate whether to print the set ID of the preprocessed newspaper issues.                                                     
- --parent                                  The newspaper object to which the generated items should be added.  Only applies to the "newspaper issue" level object. If        
+ --directory_dedup                         A flag to indicate that we should avoid repreprocessing newspaper issues which are located in directories.
+ --do_not_generate_hocr                    A flag to disallow conditional HOCR generation.
+ --do_not_generate_ocr                     A flag to disallow conditional OCR generation.
+ --email_admin                             A flag to notify the site admin when the newspaper issue is fully ingested (depends on Rules being enabled).
+ --namespace                               The namespace for objects created by this command.  Defaults to namespace set in Fedora config.
+ --output_set_id                           A flag to indicate whether to print the set ID of the preprocessed newspaper issues.
+ --parent                                  The newspaper object to which the generated items should be added.  Only applies to the "newspaper issue" level object. If
                                            "directory" and the directory containing the newspaper issue description is a valid PID, it will be set as the parent. If this is 
-                                           specified and itself is a PID, all newspapers issue will be related to the given PID. Required.                                   
- --parent_relationship_pred                The predicate of the relationship to the parent. Defaults to "isMemberOf".                                                        
- --parent_relationship_uri                 The namespace URI of the relationship to the parent. Defaults to "info:fedora/fedora-system:def/relations-external#".             
- --scan_target                             The target to directory or zip file to scan. Required.                                                                            
- --type                                    Either "directory" or "zip". Required.                                                                                            
+                                           specified and itself is a PID, all newspapers issue will be related to the given PID. Required.
+ --parent_relationship_pred                The predicate of the relationship to the parent. Defaults to "isMemberOf".
+ --parent_relationship_uri                 The namespace URI of the relationship to the parent. Defaults to "info:fedora/fedora-system:def/relations-external#".
+ --scan_target                             The target to directory or zip file to scan. Required.
+ --type                                    Either "directory" or "zip". Required.
  --wait_for_metadata                       A flag to indicate that we should hold off on trying to ingest newspaper issues until we have metadata available for them at the  
                                            newspaper issue level.
 

--- a/includes/islandora_newspaper_batch.inc
+++ b/includes/islandora_newspaper_batch.inc
@@ -447,7 +447,19 @@ class IslandoraNewspaperIssueBatchObject extends IslandoraNewspaperFlatBatchObje
  * Class IslandoraNewspaperPageBatchObject.
  */
 class IslandoraNewspaperPageBatchObject extends IslandoraNewspaperFlatBatchObject {
+
+  /**
+   * The parent PID.
+   *
+   * @var string
+   */
   protected $parentId;
+
+  /**
+   * The sequence number of this page inside the parent.
+   *
+   * @var integer
+   */
   protected $sequenceNumber;
 
   /**

--- a/includes/islandora_newspaper_batch.inc
+++ b/includes/islandora_newspaper_batch.inc
@@ -458,7 +458,7 @@ class IslandoraNewspaperPageBatchObject extends IslandoraNewspaperFlatBatchObjec
   /**
    * The sequence number of this page inside the parent.
    *
-   * @var integer
+   * @var int
    */
   protected $sequenceNumber;
 

--- a/islandora_newspaper_batch.drush.inc
+++ b/islandora_newspaper_batch.drush.inc
@@ -70,6 +70,10 @@ function islandora_newspaper_batch_drush_command() {
       'directory_dedup' => array(
         'description' => 'A flag to indicate that we should avoid repreprocessing newspaper issues which are located in directories.',
       ),
+      'output_set_id' => array(
+        'description' => 'A flag to indicate whether to print the set ID of the preprocessed newspaper issues.',
+        'value' => 'optional',
+      ),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -132,6 +136,10 @@ function drush_islandora_newspaper_batch_preprocess() {
 
   // Pass the preprocessor off to run.
   $preprocessed = islandora_batch_handle_preprocessor($preprocessor);
+
+  if (drush_get_option('output_set_id', FALSE)) {
+    drush_print($preprocessor->getSetId());
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1875

# What does this Pull Request do?

Add a new drush option to output the set id when executed on the command line.

# How should this be tested?

Pull in the PR.
Pre-process a newspaper both setting and not setting the `--output_set_id`.
When processed see if you do (or don't) get the output set id number.

For example:
```
> drush -r /var/www/drupal -u 1 inbp --namespace=islandora --parent=islandora:myNewspaper \
--type=directory --scan_target=/my/source/files --output_set_id 


4030
```

# Additional Notes:

Example:
* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? Updated readme with new option.
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers @mjordan 
